### PR TITLE
SLING-9569: Emit error code when error event received if available

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/ExceptionEventSender.java
+++ b/src/main/java/org/apache/sling/distribution/journal/ExceptionEventSender.java
@@ -35,7 +35,8 @@ public class ExceptionEventSender {
     public static final String ERROR_TOPIC = "org/apache/sling/distribution/journal/errors";
     public static final String KEY_MESSAGE = "message";
     public static final String KEY_TYPE = "type";
-    
+    public static final String KEY_ERROR_CODE = "errorCode";
+
     private final EventAdmin eventAdmin;
 
     public ExceptionEventSender(@Nullable EventAdmin eventAdmin) {
@@ -46,6 +47,12 @@ public class ExceptionEventSender {
         Map<String, String> props = new HashMap<>();
         props.put(KEY_TYPE, e.getClass().getName());
         props.put(KEY_MESSAGE, e.getMessage());
+        if (e instanceof MessagingException) {
+            String errorCode = ((MessagingException) e).getResponseCode();
+            if ((errorCode != null) && !errorCode.isEmpty()) {
+                props.put(KEY_ERROR_CODE, errorCode);
+            }
+        }
         return new Event(ERROR_TOPIC, props);
     }
 

--- a/src/main/java/org/apache/sling/distribution/journal/MessagingException.java
+++ b/src/main/java/org/apache/sling/distribution/journal/MessagingException.java
@@ -22,6 +22,8 @@ public class MessagingException extends RuntimeException {
 
     private static final long serialVersionUID = 2381842058778043644L;
 
+    private String responseCode;
+
     public MessagingException(String message) {
         super(message);
     }
@@ -30,4 +32,12 @@ public class MessagingException extends RuntimeException {
         super(message, cause);
     }
 
+    public MessagingException(String message, String responseCode) {
+        super(message);
+        this.responseCode = responseCode;
+    }
+
+    public String getResponseCode() {
+        return responseCode;
+    }
 }


### PR DESCRIPTION
- Allow to send error code in the error event if available from MessagingException