### PR TITLE
SLING-9593: Abstract out binary handling to allow plugging of different stores

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/BinaryStore.java
+++ b/src/main/java/org/apache/sling/distribution/journal/BinaryStore.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.distribution.journal;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Abstraction for storing binaries
+ */
+public interface BinaryStore<R, D> {
+
+    InputStream get(R resourceResolver, String reference) throws IOException;
+
+    String store(R resourceResolver, D disPkg, long pkgLength)
+        throws IOException;
+}

--- a/src/main/java/org/apache/sling/distribution/journal/BinaryStore.java
+++ b/src/main/java/org/apache/sling/distribution/journal/BinaryStore.java
@@ -24,10 +24,24 @@ import java.io.InputStream;
 /**
  * Abstraction for storing binaries
  */
-public interface BinaryStore<R, D> {
+public interface BinaryStore {
 
-    InputStream get(R resourceResolver, String reference) throws IOException;
+    /**
+     * Return an input stream for the identifier
+     *
+     * @param reference binary reference
+     * @return
+     * @throws IOException
+     */
+    InputStream get(String reference) throws IOException;
 
-    String store(R resourceResolver, D disPkg, long pkgLength)
-        throws IOException;
+    /**
+     * Return the reference for the
+     * @param id binary identifier
+     * @param stream stream to store
+     * @param length length of the stream
+     * @return
+     * @throws IOException
+     */
+    String put(String id, InputStream stream, long length) throws IOException;
 }


### PR DESCRIPTION
- Introduced an interface BinaryStore and JcrBinaryStore as the default implementation storing the binaries in JCR with no change in the existing strategy of storing based on size.