### PR TITLE
SLING-10227: Improvement in distribution logging to log id generated …

### DIFF
--- a/src/main/java/org/apache/sling/distribution/journal/messages/PackageMessage.java
+++ b/src/main/java/org/apache/sling/distribution/journal/messages/PackageMessage.java
@@ -74,10 +74,6 @@ public class PackageMessage {
             out.append(", pkgBinary.length=");
             out.append(pkgBinary.length);
         }
-        if (pkgBinaryRef != null) {
-            out.append(", pkgBinaryRef=");
-            out.append(pkgBinaryRef);
-        }
         out.append(", paths=");
         out.append(abbreviate(paths));
         out.append(", deepPaths=");


### PR DESCRIPTION
…for binary reference and not log reference

- Remove logging the binaryRef prop as it may leak secrets from implementations