### PR TITLE
chore: upgrade parent POM to v66 and apply code style fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Licensed to the Apache Software Foundation (ASF) under one
     or more contributor license agreements.  See the NOTICE file
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>49</version>
+        <version>66</version>
         <relativePath />
     </parent>
 
@@ -39,17 +39,17 @@
     <name>Apache Sling Journal based Content Distribution - Messages bundle</name>
     <description>Implementation of the messages to support Apache Sling Content Distribution on top of an append-only persisted log</description>
 
+    <scm>
+        <connection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-distribution-journal-messages.git</connection>
+        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-distribution-journal-messages.git</developerConnection>
+        <tag>org.apache.sling.distribution.journal.messages-0.5.12</tag>
+        <url>https://github.com/apache/sling-org-apache-sling-distribution-journal-messages.git</url>
+    </scm>
+
     <properties>
         <sling.java.version>11</sling.java.version>
         <project.build.outputTimestamp>2025-05-15T15:15:10Z</project.build.outputTimestamp>
     </properties>
-
-    <scm>
-        <connection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-distribution-journal-messages.git</connection>
-        <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/sling-org-apache-sling-distribution-journal-messages.git</developerConnection>
-        <url>https://github.com/apache/sling-org-apache-sling-distribution-journal-messages.git</url>
-        <tag>org.apache.sling.distribution.journal.messages-0.5.12</tag>
-    </scm>
 
     <!-- ======================================================================= -->
     <!-- D E P E N D E N C I E S -->
@@ -63,7 +63,7 @@
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>
-            <artifactId>osgi.cmpn</artifactId>
+            <artifactId>org.osgi.service.event</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -75,8 +75,8 @@
         <dependency>
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
-            <scope>provided</scope>
             <version>2.0.0</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Test -->

--- a/src/main/java/org/apache/sling/distribution/journal/BinaryStore.java
+++ b/src/main/java/org/apache/sling/distribution/journal/BinaryStore.java
@@ -18,11 +18,11 @@
  */
 package org.apache.sling.distribution.journal;
 
-import org.osgi.annotation.versioning.ProviderType;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
 
 /**
  * Abstraction for storing binaries
@@ -69,6 +69,6 @@ public interface BinaryStore {
      * @return
      * @throws IOException
      */
-    String put(String id, InputStream stream, long length, String contentType, Map<String, String> metadata) throws IOException;
-
+    String put(String id, InputStream stream, long length, String contentType, Map<String, String> metadata)
+            throws IOException;
 }

--- a/src/main/java/org/apache/sling/distribution/journal/ExceptionEventSender.java
+++ b/src/main/java/org/apache/sling/distribution/journal/ExceptionEventSender.java
@@ -18,10 +18,10 @@
  */
 package org.apache.sling.distribution.journal;
 
+import javax.annotation.Nullable;
+
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.annotation.Nullable;
 
 import org.osgi.service.event.Event;
 import org.osgi.service.event.EventAdmin;

--- a/src/main/java/org/apache/sling/distribution/journal/FullMessage.java
+++ b/src/main/java/org/apache/sling/distribution/journal/FullMessage.java
@@ -27,13 +27,12 @@ public class FullMessage<T> {
         this.info = info;
         this.message = message;
     }
-    
+
     public MessageInfo getInfo() {
         return info;
     }
-    
+
     public T getMessage() {
         return message;
     }
-
 }

--- a/src/main/java/org/apache/sling/distribution/journal/HandlerAdapter.java
+++ b/src/main/java/org/apache/sling/distribution/journal/HandlerAdapter.java
@@ -21,11 +21,11 @@ package org.apache.sling.distribution.journal;
 public class HandlerAdapter<T> {
     private final Class<T> type;
     private final MessageHandler<T> handler;
-    
+
     public static <T> HandlerAdapter<T> create(Class<T> type, MessageHandler<T> handler) {
         return new HandlerAdapter<>(type, handler);
     }
-    
+
     private HandlerAdapter(Class<T> type, MessageHandler<T> handler) {
         this.type = type;
         this.handler = handler;
@@ -38,9 +38,10 @@ public class HandlerAdapter<T> {
     public MessageHandler<T> getHandler() {
         return this.handler;
     }
-    
+
     @Override
     public String toString() {
-        return "Message handler for type=" + type.getName() + ", handler=" + handler.getClass().getName();
+        return "Message handler for type=" + type.getName() + ", handler="
+                + handler.getClass().getName();
     }
 }

--- a/src/main/java/org/apache/sling/distribution/journal/JournalAvailable.java
+++ b/src/main/java/org/apache/sling/distribution/journal/JournalAvailable.java
@@ -21,6 +21,4 @@ package org.apache.sling.distribution.journal;
 /**
  * Marker service to signal that the Journal service is available and correctly configured
  */
-public interface JournalAvailable {
-
-}
+public interface JournalAvailable {}

--- a/src/main/java/org/apache/sling/distribution/journal/MessageInfo.java
+++ b/src/main/java/org/apache/sling/distribution/journal/MessageInfo.java
@@ -29,6 +29,6 @@ public interface MessageInfo {
     long getOffset();
 
     long getCreateTime();
-    
+
     Map<String, String> getProps();
 }

--- a/src/main/java/org/apache/sling/distribution/journal/MessageSender.java
+++ b/src/main/java/org/apache/sling/distribution/journal/MessageSender.java
@@ -30,9 +30,8 @@ public interface MessageSender<T> extends Consumer<T> {
     default void accept(T payload) {
         send(payload);
     }
-    
-    void send(T payload) throws MessagingException;
-    
-    void send(T payload, Map<String, String> properties) throws MessagingException;
 
+    void send(T payload) throws MessagingException;
+
+    void send(T payload, Map<String, String> properties) throws MessagingException;
 }

--- a/src/main/java/org/apache/sling/distribution/journal/MessagingException.java
+++ b/src/main/java/org/apache/sling/distribution/journal/MessagingException.java
@@ -27,7 +27,7 @@ public class MessagingException extends RuntimeException {
     public MessagingException(String message) {
         super(message);
     }
-    
+
     public MessagingException(String message, Exception cause) {
         super(message, cause);
     }

--- a/src/main/java/org/apache/sling/distribution/journal/MessagingProvider.java
+++ b/src/main/java/org/apache/sling/distribution/journal/MessagingProvider.java
@@ -38,16 +38,13 @@ public interface MessagingProvider {
      */
     <T> MessageSender<T> createSender(String topic);
 
-    default Closeable createPoller(
-            String topicName,
-            Reset reset,
-            HandlerAdapter<?> ... adapters) {
+    default Closeable createPoller(String topicName, Reset reset, HandlerAdapter<?>... adapters) {
         return createPoller(topicName, reset, null, adapters);
     }
 
     /**
      * Create a poller which listens to a topic and starts at a given reset or assigned offset.
-     * 
+     *
      * @param topicName name of the topic
      * @param reset fallback in case no assign is given or the assigned offset not valid
      * @param assign opaque implementation dependent assign string (can be null)
@@ -58,7 +55,7 @@ public interface MessagingProvider {
 
     /**
      * Create a poller which listens to a topic and starts at a given reset or assigned offset.
-     * 
+     *
      * @param topicName name of the topic
      * @param reset fallback in case no assign is given or the assigned offset not valid
      * @param assign opaque implementation dependent assign string (can be null)
@@ -67,14 +64,18 @@ public interface MessagingProvider {
      * @param adapters list of listener adapters
      * @return closeable handle of the poller
      */
-    default Closeable createPoller(String topicName, Reset reset, String assign, Map<String, String> filterProperties,
+    default Closeable createPoller(
+            String topicName,
+            Reset reset,
+            String assign,
+            Map<String, String> filterProperties,
             HandlerAdapter<?>... adapters) {
         return createPoller(topicName, reset, assign, adapters);
     }
 
     /**
      * Validate that a topic is suitably set up for the messaging implementation
-     * 
+     *
      * @param topic topic name
      * @throws MessagingException exception in case the topic is not suitable
      */
@@ -82,7 +83,7 @@ public interface MessagingProvider {
 
     /**
      * Retrieve earliest or latest offset for a topic
-     * 
+     *
      * @param topicName name of the topic
      * @param reset latest or earliest
      * @return offset
@@ -92,28 +93,27 @@ public interface MessagingProvider {
     /**
      * Create assign String to feed into poller based on a given offset.
      * The inner format of the assign string is implementation specific.
-     *  
+     *
      * @param offset
      * @return assign String
      */
     String assignTo(long offset);
-    
+
     /**
      * Get assign String to feed into createPoller based on either earliest or latest and a relative offset.
      * The inner format of the assign string is implementation specific.
-     * 
+     *
      * @param reset reference point
      * @param relativeOffset relative offset
      * @return assign String
      */
     String assignTo(Reset reset, long relativeOffset);
-    
+
     /**
      * Return the uri of the messaging system backend.
      * The uri must be unique regarding the validity of per topic offsets.
-     *  
+     *
      * @return uri
      */
     URI getServerUri();
-
 }

--- a/src/main/java/org/apache/sling/distribution/journal/Reset.java
+++ b/src/main/java/org/apache/sling/distribution/journal/Reset.java
@@ -19,7 +19,7 @@
 package org.apache.sling.distribution.journal;
 
 // Do not change the enum names. Implementation depends on the exact names.
-public enum Reset { 
-    earliest, // earliest available offset 
-    latest  // latest available offset
+public enum Reset {
+    earliest, // earliest available offset
+    latest // latest available offset
 }

--- a/src/main/java/org/apache/sling/distribution/journal/RunnableUtil.java
+++ b/src/main/java/org/apache/sling/distribution/journal/RunnableUtil.java
@@ -23,8 +23,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class RunnableUtil {
 
-    private RunnableUtil() {
-    }
+    private RunnableUtil() {}
 
     public static Thread startBackgroundThread(Runnable runnable, String threadName) {
         Thread thread = new Thread(runnable, threadName);

--- a/src/main/java/org/apache/sling/distribution/journal/messages/ClearCommand.java
+++ b/src/main/java/org/apache/sling/distribution/journal/messages/ClearCommand.java
@@ -28,14 +28,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ClearCommand {
-    
+
     // Subscriber agent Sling identifier
     String subSlingId;
-    
+
     // Subscriber agent name
     String subAgentName;
-    
+
     String pubAgentName;
-    
+
     long offset;
 }

--- a/src/main/java/org/apache/sling/distribution/journal/messages/DiscoveryMessage.java
+++ b/src/main/java/org/apache/sling/distribution/journal/messages/DiscoveryMessage.java
@@ -30,14 +30,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class DiscoveryMessage {
-    
+
     // Subscriber agent Sling identifier
     String subSlingId;
-    
+
     // Subscriber agent name
     String subAgentName;
-    
+
     SubscriberConfig subscriberConfiguration;
-    
+
     List<SubscriberState> subscriberStates;
 }

--- a/src/main/java/org/apache/sling/distribution/journal/messages/ListPrinter.java
+++ b/src/main/java/org/apache/sling/distribution/journal/messages/ListPrinter.java
@@ -22,9 +22,8 @@ import java.util.Iterator;
 import java.util.List;
 
 public final class ListPrinter {
-    
-    private ListPrinter() {
-    }
+
+    private ListPrinter() {}
 
     static String print(List<String> list, boolean abbreviate) {
         if (list == null) {
@@ -47,5 +46,4 @@ public final class ListPrinter {
         abbr.append("]");
         return abbr.toString();
     }
-
 }

--- a/src/main/java/org/apache/sling/distribution/journal/messages/LogMessage.java
+++ b/src/main/java/org/apache/sling/distribution/journal/messages/LogMessage.java
@@ -28,17 +28,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class LogMessage {
-    
+
     // Publisher agent name
     String pubAgentName;
-    
+
     // Subscriber agent Sling identifier
     String subSlingId;
-    
+
     // Subscriber agent name
     String subAgentName;
-    
+
     String message;
-    
+
     String stacktrace;
 }

--- a/src/main/java/org/apache/sling/distribution/journal/messages/OffsetMessage.java
+++ b/src/main/java/org/apache/sling/distribution/journal/messages/OffsetMessage.java
@@ -19,10 +19,9 @@
 package org.apache.sling.distribution.journal.messages;
 
 /**
- * Synthetic message create by poller to signal the offset 
+ * Synthetic message create by poller to signal the offset
  * when starting from earliest or latest.
  * This allows the user of the poller to process the offset
  * even if there is no message coming in.
  */
-public class OffsetMessage {
-}
+public class OffsetMessage {}

--- a/src/main/java/org/apache/sling/distribution/journal/messages/PackageMessage.java
+++ b/src/main/java/org/apache/sling/distribution/journal/messages/PackageMessage.java
@@ -18,9 +18,9 @@
  */
 package org.apache.sling.distribution.journal.messages;
 
-import lombok.*;
-
 import java.util.*;
+
+import lombok.*;
 
 @Data
 @Builder
@@ -52,7 +52,7 @@ public class PackageMessage {
         INVALIDATE,
         TEST;
     }
-    
+
     public String toString() {
         return toString(true);
     }

--- a/src/main/java/org/apache/sling/distribution/journal/messages/PackageStatusMessage.java
+++ b/src/main/java/org/apache/sling/distribution/journal/messages/PackageStatusMessage.java
@@ -54,16 +54,19 @@ public class PackageStatusMessage {
         Status(int number) {
             this.number = number;
         }
-        
+
         public int getNumber() {
             return number;
         }
-        
+
         public static Status fromNumber(int number) {
             switch (number) {
-                case 0: return REMOVED_FAILED;
-                case 1: return REMOVED;
-                case 2: return IMPORTED;
+                case 0:
+                    return REMOVED_FAILED;
+                case 1:
+                    return REMOVED;
+                case 2:
+                    return IMPORTED;
             }
             throw new IllegalStateException("Unknown number " + number);
         }

--- a/src/main/java/org/apache/sling/distribution/journal/messages/SubscriberConfig.java
+++ b/src/main/java/org/apache/sling/distribution/journal/messages/SubscriberConfig.java
@@ -33,7 +33,7 @@ public class SubscriberConfig {
     /**
      * The max number of retry attempts to process this package. A value smaller
      * than zero indicates an infinite number of retry attempts. A value greater or
-     * equal to zero indicates a specific number of retry attempts. 
+     * equal to zero indicates a specific number of retry attempts.
      */
     int maxRetries;
 }

--- a/src/main/java/org/apache/sling/distribution/journal/messages/SubscriberState.java
+++ b/src/main/java/org/apache/sling/distribution/journal/messages/SubscriberState.java
@@ -30,10 +30,10 @@ import lombok.NoArgsConstructor;
 public class SubscriberState {
     // Publisher agent name
     String pubAgentName;
-    
+
     // Last processed offset on the Subscriber agent
     long offset;
-    
+
     // Nb of retries for the current offset on the Subscriber agent
     int retries;
 }

--- a/src/main/java/org/apache/sling/distribution/journal/package-info.java
+++ b/src/main/java/org/apache/sling/distribution/journal/package-info.java
@@ -18,4 +18,3 @@
  */
 @org.osgi.annotation.versioning.Version("1.7.0")
 package org.apache.sling.distribution.journal;
-

--- a/src/test/java/org/apache/sling/distribution/journal/messages/ListPrinterTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/messages/ListPrinterTest.java
@@ -18,15 +18,15 @@
  */
 package org.apache.sling.distribution.journal.messages;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNull;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 
 public class ListPrinterTest {
     @Test
@@ -51,7 +51,7 @@ public class ListPrinterTest {
         List<String> one = Arrays.asList("/a/path", "/another/one", "/yet/another/one");
         assertThat(ListPrinter.print(one, true), equalTo("[/a/path, ... 2 more]"));
     }
-    
+
     @Test
     public void testPrintManyPaths() {
         List<String> one = Arrays.asList("/a/path", "/another/one", "/yet/another/one");

--- a/src/test/java/org/apache/sling/distribution/journal/messages/PackageMessageTest.java
+++ b/src/test/java/org/apache/sling/distribution/journal/messages/PackageMessageTest.java
@@ -18,10 +18,6 @@
  */
 package org.apache.sling.distribution.journal.messages;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
@@ -31,10 +27,13 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.stream.Collectors;
 
-import org.junit.Test;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PackageMessageTest {
 
@@ -44,11 +43,10 @@ public class PackageMessageTest {
         writer.writeValue(outWriter, message);
         return outWriter.getBuffer().toString();
     }
-    
+
     @Test
     public void testDefaults() {
-        PackageMessage message = PackageMessage.builder()
-            .build();
+        PackageMessage message = PackageMessage.builder().build();
         assertThat(message.getPaths(), notNullValue());
         assertThat(message.getDeepPaths(), notNullValue());
         assertThat(message.getMetadata(), notNullValue());
@@ -59,10 +57,10 @@ public class PackageMessageTest {
     public void testSerialize() throws IOException {
         byte[] pkgBinary = "dummy".getBytes();
         PackageMessage message = PackageMessage.builder()
-            .paths(Collections.singletonList("/test"))
-            .pkgBinary(pkgBinary)
-            .metadata(Collections.singletonMap("testMetadataField", "test"))
-            .build();
+                .paths(Collections.singletonList("/test"))
+                .pkgBinary(pkgBinary)
+                .metadata(Collections.singletonMap("testMetadataField", "test"))
+                .build();
         String serialized = serializePackageMessage(message);
         Path path = Paths.get("src/test/resources/serialized.json");
         String expected = Files.lines(path, StandardCharsets.UTF_8).collect(Collectors.joining());
@@ -81,5 +79,4 @@ public class PackageMessageTest {
         String expected = Files.lines(path, StandardCharsets.UTF_8).collect(Collectors.joining());
         assertThat(serialized, equalTo(expected));
     }
-
 }


### PR DESCRIPTION
Upgrades the sling-bundle-parent POM from version 49 to 66 and applies a set of code style and dependency cleanup changes across the module.

- Bump `sling-bundle-parent` version from 49 to 66 in `pom.xml`
- Add XML encoding declaration to `pom.xml`
- Replace `osgi.cmpn` dependency with `org.osgi.service.event`
- Fix `<version>` and `<scope>` ordering for the jsr305 dependency
- Reorder `<scm>` and `<properties>` sections in `pom.xml`
- Reorder imports to follow Java conventions (javax before java, then org.*) in several source files
- Fix trailing whitespace and blank line style issues across multiple Java source files
- Reformat long method signatures and Javadoc comment blocks for line-length compliance
- Collapse empty interface body in `JournalAvailable.java`

Note: the diff was truncated; additional formatting changes in other files may not be fully reflected above.

Co-authored-by: Maia <maia@noreply>